### PR TITLE
\r\n (improve RFC 4180 adherence in to_csv())

### DIFF
--- a/format-colors
+++ b/format-colors
@@ -104,7 +104,7 @@ def to_csv(color_dict):
     code += '%s,' % k
     code += '"%s",' % v["name"]
     code += '%s,' % v["hex"]
-    code += '%d,%d,%d\n' % v["rgb"]
+    code += '%d,%d,%d\r\n' % v["rgb"]
   return code
 
 def to_ccode(color_dict):


### PR DESCRIPTION
[RFC 4180](https://tools.ietf.org/html/rfc4180#section-1) recommends terminating a line in a comma-separated values textfile with `CR` `LF` (`\r\n` in Python). So this just adds the `\r`.